### PR TITLE
Added ToolResponseMessage in messages list for execute_turn method

### DIFF
--- a/common/execute_with_custom_tools.py
+++ b/common/execute_with_custom_tools.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 
-from typing import AsyncGenerator, List, Optional
+from typing import AsyncGenerator, List, Optional, Union
 
 from .custom_tools import CustomTool, Message, ToolResponseMessage
 
@@ -31,7 +31,7 @@ class AgentWithCustomToolExecutor:
 
     async def execute_turn(
         self,
-        messages: List[UserMessage],
+        messages: List[Union[UserMessage, ToolResponseMessage]],
         attachments: Optional[List[Attachment]] = None,
         max_iters: int = 5,
         stream: bool = True,


### PR DESCRIPTION
If you check in the file execute_with_custom_tools.py in the execute_turn method, in the end of the method we assign next_message to current_message and next_message is result_message which is a list of ToolResponseMessage but the execute_turn method allows only UserMessage in the messages argument, Hence this change.