### PR TITLE
fix run command for agent example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ cd <path-to-llama-agentic-system>
 conda activate $ENV
 llama stack run <name> # If not already started
 
-PYTHONPATH=. python examples/scripts/vacation.py localhost 5000
+PYTHONPATH=. python -m examples.agents.rag_with_memory_bank localhost 5000
 ```
 
 You should see outputs to stdout of the form --


### PR DESCRIPTION
Seeing an error when running using path: 
```
PYTHONPATH=. python examples/agents/rag_with_memory_bank.py localhost 5000
Traceback (most recent call last):
  File "/home/dineshyv/local/llama-stack-apps/examples/agents/rag_with_memory_bank.py", line 19, in <module>
    from .multi_turn import execute_turns, prompt_to_turn
ImportError: attempted relative import with no known parent package

```