### PR TITLE
[Android App] Bug fix in getting recent messages

### DIFF
--- a/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/MessageAdapter.java
+++ b/examples/android_app/app/src/main/java/com/example/llamastackandroiddemo/MessageAdapter.java
@@ -111,7 +111,7 @@ public class MessageAdapter extends ArrayAdapter<Message> {
             numOfLatestPromptMessages--;
             oldPromptID = messageToAdd.getPromptID();
           }
-          if (numOfLatestPromptMessages > 0) {
+          if (numOfLatestPromptMessages >= 0) {
             if (messageToAdd.getMessageType() == MessageType.TEXT && !messageToAdd.getText().isEmpty()) {
               recentMessages.add(messageToAdd);
             }


### PR DESCRIPTION
# What does this PR do?

Fixing a bug where getRecentSavedTextMessages() would only get CONVERSATION_HISTORY_MESSAGE_LOOKBACK - 1. Now with this fix, function will retrieve CONVERSATION_HISTORY_MESSAGE_LOOKBACK # of conversations. 

## Feature/Issue validation/testing/test plan
1. Tested with Llama 3.2 3B and confirmed with logs


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/meta-llama/llama-stack-apps/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
