### PR TITLE
Fix default model for agent store app

### DIFF
--- a/examples/agent_store/api.py
+++ b/examples/agent_store/api.py
@@ -38,7 +38,11 @@ class AgentChoice(Enum):
 class AgentStore:
     def __init__(self, host, port) -> None:
         self.client = LlamaStackClient(base_url=f"http://{host}:{port}")
-        available_models = [model.identifier for model in self.client.models.list()]
+        available_models = [
+            model.identifier
+            for model in self.client.models.list()
+            if model.model_type == "llm"
+        ]
         if not available_models:
             print(colored("No available models. Exiting.", "red"))
             sys.exit(1)


### PR DESCRIPTION

Summary:
Ran the command only to find all-MiniLM-L6-v2 is being selected by default.

```
python -m examples.agent_store.app localhost 5000

Using model: all-MiniLM-L6-v2
* Running on local URL:  http://0.0.0.0:7860
```

Test Plan:
Run the command with the change and validate that meta-llama/Llama-3.2-3B-Instruct is used instead

```
python -m examples.agent_store.app localhost 5000


Using model: meta-llama/Llama-3.2-3B-Instruct
* Running on local URL:  http://0.0.0.0:7860
```
