### PR TITLE
update iOS demos for LS0.1.3

### DIFF
--- a/examples/ios_calendar_assistant/README.md
+++ b/examples/ios_calendar_assistant/README.md
@@ -19,18 +19,18 @@ You need to set up a remote Llama Stack distributions to run this demo. Assuming
 ```
 conda create -n llama-stack python=3.10
 conda activate llama-stack
-pip install --no-cache llama-stack==0.1.0 llama-models==0.1.0 llama-stack-client==0.1.0
+pip install --no-cache llama-stack==0.1.3 llama-models==0.1.3 llama-stack-client==0.1.3
 ```
 
 Then, either:
 ```
-PYPI_VERSION=0.1.0 llama stack build --template fireworks --image-type conda
+PYPI_VERSION=0.1.3 llama stack build --template fireworks --image-type conda
 export FIREWORKS_API_KEY="<your_fireworks_api_key>"
 llama stack run fireworks
 ```
 or
 ```
-PYPI_VERSION=0.1.0 llama stack build --template together --image-type conda
+PYPI_VERSION=0.1.3 llama stack build --template together --image-type conda
 export TOGETHER_API_KEY="<your_together_api_key>"
 llama stack run together
 ```
@@ -56,12 +56,12 @@ Also, to allow the app to add event to the Calendar app, the `Info.plist` needs 
 4. Build the run the app on an iOS simulator or your device. First you may try a simple request:
 
 ```
-Create a calendar event with a meeting title as Llama Stack update for 2-3pm February 3, 2025.
+Create a calendar event with a meeting title as Llama Stack update for 2-3pm February 19, 2025.
 ```
 
 Then, a detailed meeting note:
 ```
-Date: February 4, 2025
+Date: February 20, 2025
 Time: 10:00 AM - 11:00 AM
 Location: Zoom
 Attendees:
@@ -85,7 +85,7 @@ Sarah: Good. Jane, any updates from operations?
 Jane: Yes, logistics are sorted, and we’ve confirmed the warehouse availability. The only pending item is training customer support for the new product.
 Sarah: Let’s coordinate with the training team to expedite that. Anything else?
 Mike: Quick note—can we get feedback on the beta version by Friday?
-Sarah: Yes, let’s make that a priority. Anything else? No? Great. Thanks, everyone. Let’s meet again next week from 4-5pm on February 11, 2025 to review progress.
+Sarah: Yes, let’s make that a priority. Anything else? No? Great. Thanks, everyone. Let’s meet again next week from 4-5pm on February 27, 2025 to review progress.
 ```
 
 You'll see a summary, action items and a Calendar event created, made possible by Llama Stack's custom tool calling API support and Llama 3.1's tool calling capability.

--- a/examples/ios_calendar_assistant/iOSCalendarAssistant/ContentView.swift
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistant/ContentView.swift
@@ -24,7 +24,9 @@ struct ContentView: View {
   @State private var showAlert = false
   @State private var alertMessage = ""
   
-  private let agent = RemoteAgents(url: URL(string: "http://127.0.0.1:5000")!)
+  // replace the URL string if you build and run your own Llama Stack distro as shown in https://github.com/meta-llama/llama-stack-apps/tree/main/examples/ios_quick_demo#optional-build-and-run-own-llama-stack-distro
+  private let agent = RemoteAgents(url: URL(string: "https://llama-stack.together.ai")!)
+  
   @State var agentId = ""
   @State var agenticSystemSessionId = ""
 
@@ -112,8 +114,8 @@ struct ContentView: View {
         let request = Components.Schemas.CreateAgentTurnRequest(
         messages: [
           .UserMessage(Components.Schemas.UserMessage(
-            content: .case1("Summarize the following conversation in 1-2 sentences:\n\n \(prompt)"),
-            role: .user
+            role: .user,
+            content: .case1("Summarize the following conversation in 1-2 sentences:\n\n \(prompt)")
           ))
         ],
         stream: true
@@ -158,8 +160,8 @@ struct ContentView: View {
     let request = Components.Schemas.CreateAgentTurnRequest(
       messages: [
         .UserMessage(Components.Schemas.UserMessage(
-          content: .case1("List out any action items based on this text:\n\n \(prompt)"),
-          role: .user
+          role: .user,
+          content: .case1("List out any action items based on this text:\n\n \(prompt)")
         ))
       ],
       stream: true
@@ -199,8 +201,8 @@ struct ContentView: View {
     let request = Components.Schemas.CreateAgentTurnRequest(
       messages: [
         .UserMessage(Components.Schemas.UserMessage(
-          content: .case1("Call functions as needed to handle any actions in the following text:\n\n" + prompt),
-          role: .user
+          role: .user,
+          content: .case1("Call functions as needed to handle any actions in the following text:\n\n" + prompt)
         ))
       ],
       stream: true
@@ -283,11 +285,10 @@ struct ContentView: View {
             request: Components.Schemas.CreateAgentRequest(
               agent_config: Components.Schemas.AgentConfig(
                 client_tools: [ CustomTools.getCreateEventToolForAgent() ],
-                enable_session_persistence: false,
-                instructions: "You are a helpful assistant",
                 max_infer_iters: 1,
-                model: "meta-llama/Llama-3.1-8B-Instruct"
-                //toolgroups: ["builtin::websearch"],
+                model: "meta-llama/Llama-3.1-8B-Instruct",
+                instructions: "You are a helpful assistant",
+                enable_session_persistence: false
               )
             )
           )

--- a/examples/ios_quick_demo/README.md
+++ b/examples/ios_quick_demo/README.md
@@ -13,18 +13,18 @@ You need to set up a remote Llama Stack distributions to run this demo. Assuming
 ```
 conda create -n llama-stack python=3.10
 conda activate llama-stack
-pip install --no-cache llama-stack==0.1.0 llama-models==0.1.0 llama-stack-client==0.1.0
+pip install --no-cache llama-stack==0.1.3 llama-models==0.1.3 llama-stack-client==0.1.3
 ```
 
 Then, either:
 ```
-PYPI_VERSION=0.1.0 llama stack build --template fireworks --image-type conda
+PYPI_VERSION=0.1.3 llama stack build --template fireworks --image-type conda
 export FIREWORKS_API_KEY="<your_fireworks_api_key>"
 llama stack run fireworks
 ```
 or
 ```
-PYPI_VERSION=0.1.0 llama stack build --template together --image-type conda
+PYPI_VERSION=0.1.3 llama stack build --template together --image-type conda
 export TOGETHER_API_KEY="<your_together_api_key>"
 llama stack run together
 ```
@@ -35,7 +35,7 @@ The default port is 5000 for `llama stack run` and you can specify a different p
 
 1. Double click `iOSQuickDemo/iOSQuickDemo.xcodeproj` to open it in Xcode.
 
-2. Under the iOSQuickDemo project - Package Dependencies, click the + sign, then add `https://github.com/meta-llama/llama-stack-client-swift` at the top right and 0.1.0 in the Dependency Rule, then click Add Package.
+2. Under the iOSQuickDemo project - Package Dependencies, click the + sign, then add `https://github.com/meta-llama/llama-stack-client-swift` at the top right and 0.1.3 in the Dependency Rule, then click Add Package.
 
 ![](quick1.png)
 ![](quick2.png)
@@ -43,7 +43,7 @@ The default port is 5000 for `llama stack run` and you can specify a different p
 3. (Optional) Replace the `RemoteInference` url string in `ContentView.swift` below with the host IP and port of the remote Llama Stack distro in Build and Run Own Llama Stack Distro:
 
 ```
-let inference = RemoteInference(url: URL(string: "http://127.0.0.1:5000")!)
+let inference = RemoteInference(url: URL(string: "https://llama-stack.together.ai")!)
 ```
 
 **Note:** In order for the app to access the remote URL, the app's `Info.plist` needs to have the entry `App Transport Security Settings` with `Allow Arbitrary Loads` set to YES.
@@ -61,34 +61,34 @@ Inside the async return of the `chatCompletion`, each returned text chunk is app
 for await chunk in try await inference.chatCompletion(
     request:
         Components.Schemas.ChatCompletionRequest(
+        model_id: "meta-llama/Llama-3.1-8B-Instruct",
         messages: [
             .user(
             Components.Schemas.UserMessage(
+                role: .user,
                 content:
                     .InterleavedContentItem(
                         .text(Components.Schemas.TextContentItem(
-                            text: userInput,
-                            _type: .text
+                            _type: .text,
+                            text: userInput
                         )
                     )
-                ),
-                role: .user
+                )
             )
         )
         ],
-        model_id: "meta-llama/Llama-3.1-8B-Instruct",
         stream: true)
     ) {
         switch (chunk.event.delta) {
-            case .text(let s):
-                message += s.text
-                break
-            case .image(let s):
-                print("> \(s)")
-                break
-            case .tool_call(let s):
-                print("> \(s)")
-                break
+        case .text(let s):
+            message += s.text
+            break
+        case .image(let s):
+            print("> \(s)")
+            break
+        case .tool_call(let s):
+            print("> \(s)")
+            break
         }
     }
 ```

--- a/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/ContentView.swift
+++ b/examples/ios_quick_demo/iOSQuickDemo/iOSQuickDemo/ContentView.swift
@@ -17,13 +17,16 @@ struct ContentView: View {
 
   var body: some View {
     VStack(spacing: 20) {
-      Text(message.isEmpty ? "Click Inference to see Llama's answer" : message)
+      ScrollView {
+        Text(message.isEmpty ? "Click Inference to see Llama's answer" : message)
           .font(.headline)
           .foregroundColor(.blue)
           .padding()
           .frame(maxWidth: .infinity)
           .background(Color.gray.opacity(0.2))
           .cornerRadius(8)
+      }
+      .frame(maxHeight: 500)
 
       VStack(alignment: .leading, spacing: 10) {
         Text("Question")
@@ -57,6 +60,8 @@ struct ContentView: View {
       return
     }
 
+    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    
     message = ""
 
     let workItem = DispatchWorkItem {
@@ -74,22 +79,22 @@ struct ContentView: View {
           for await chunk in try await inference.chatCompletion(
             request:
               Components.Schemas.ChatCompletionRequest(
+                model_id: "meta-llama/Llama-3.1-8B-Instruct",
                 messages: [
                   .user(
                     Components.Schemas.UserMessage(
+                      role: .user,
                       content:
                           .InterleavedContentItem(
                               .text(Components.Schemas.TextContentItem(
-                                  text: userInput,
-                                  _type: .text
+                                  _type: .text,
+                                  text: userInput
                               )
                           )
-                      ),
-                      role: .user
+                      )
                   )
                 )
               ],
-              model_id: "meta-llama/Llama-3.1-8B-Instruct",
               stream: true)
           ) {
             switch (chunk.event.delta) {


### PR DESCRIPTION
Updated demo for Llama Stack 0.1.3 ([release](https://github.com/meta-llama/llama-stack/releases/tag/v0.1.3) and [spec](https://github.com/meta-llama/llama-stack/blob/main/docs/_static/llama-stack-spec.html)). 

Need to use the updated iOS Swift SDK [here](https://github.com/meta-llama/llama-stack-client-swift/pull/20) to build and run.