### PR TITLE
fix: Allows users to configure host/port in react agent example

### DIFF
--- a/examples/agents/react_agent.py
+++ b/examples/agents/react_agent.py
@@ -35,9 +35,9 @@ def torchtune(query: str = "torchtune"):
     return dummy_response
 
 
-def main():
+def main(host: str, port: int):
     client = LlamaStackClient(
-        base_url="http://localhost:8321",
+        base_url=f"http://{host}:{port}",
     )
 
     model = "meta-llama/Llama-3.1-8B-Instruct"


### PR DESCRIPTION
This is to be consistent with other examples.