### PR TITLE
Require yfinance >= 0.2.54 to avoid rate limiting issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fire
 python-dotenv
 setuptools
-yfinance
+yfinance>=0.2.54
 gradio
 llama-stack-client>=0.1.0


### PR DESCRIPTION
See https://github.com/ranaroussi/yfinance/pull/2277 and https://github.com/ranaroussi/yfinance/issues/2276. 

Getting very frequent rate limiting issue since yesterday:

```
1 Failed download:
['GOOG']: YFRateLimitError('Too Many Requests. Rate limited. Try after a while.')
```