### PR TITLE
fix: react_agent.py needs tavily_search_api_key

### DIFF
--- a/examples/agents/react_agent.py
+++ b/examples/agents/react_agent.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 import uuid
+import os
 
 import fire
 
@@ -38,6 +39,7 @@ def torchtune(query: str = "torchtune"):
 def main(host: str, port: int):
     client = LlamaStackClient(
         base_url=f"http://{host}:{port}",
+        provider_data={"tavily_search_api_key": os.getenv("TAVILY_SEARCH_API_KEY")},
     )
 
     model = "meta-llama/Llama-3.3-70B-Instruct"


### PR DESCRIPTION
# What does this PR do?

This PR adds `provider_data={"tavily_search_api_key": os.getenv("TAVILY_SEARCH_API_KEY")}` to the client definition in examples/agents/react_agent.py. Without it, users can get the following error if they have not previously added the provider data to their server:

```
llama_stack_client.BadRequestError: Error code: 400 - {'detail': 'Invalid value: Pass Search provider\'s API Key in the header X-LlamaStack-Provider-Data as { "tavily_search_api_key": <your api key>}'}
```

## Feature/Issue validation/testing/test plan

- [ ] Test A
I started a fresh Llama Stack server and ran examples/agents/react_agent.py as is, and I received the error above. 


- [ ] Test B
I started a fresh Llama Stack server and ran examples/agents/react_agent.py with the changes in this PR and the example ran as expected. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/meta-llama/llama-stack-apps/blob/main/CONTRIBUTING.md#pull-requests),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

Thanks for contributing 🎉!
