### PR TITLE
Clean-up iOSCalendarAssitantWithLocalInf Project Dependencies

### DIFF
--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.pbxproj
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.pbxproj
@@ -7,25 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		5C176BAB2CD556880015AE3B /* backend_coreml in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BAA2CD556880015AE3B /* backend_coreml */; };
-		5C176BAD2CD556880015AE3B /* backend_coreml_debug in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BAC2CD556880015AE3B /* backend_coreml_debug */; };
-		5C176BAF2CD556880015AE3B /* backend_mps in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BAE2CD556880015AE3B /* backend_mps */; };
-		5C176BB12CD556880015AE3B /* backend_mps_debug in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BB02CD556880015AE3B /* backend_mps_debug */; };
-		5C176BB32CD556880015AE3B /* backend_xnnpack in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BB22CD556880015AE3B /* backend_xnnpack */; };
-		5C176BB52CD556880015AE3B /* backend_xnnpack_debug in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BB42CD556880015AE3B /* backend_xnnpack_debug */; };
-		5C176BB72CD5568E0015AE3B /* kernels_custom in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BB62CD5568E0015AE3B /* kernels_custom */; };
-		5C176BB92CD5568E0015AE3B /* kernels_custom_debug in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BB82CD5568E0015AE3B /* kernels_custom_debug */; };
-		5C176BBB2CD5568E0015AE3B /* kernels_optimized in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BBA2CD5568E0015AE3B /* kernels_optimized */; };
-		5C176BBD2CD5568E0015AE3B /* kernels_optimized_debug in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BBC2CD5568E0015AE3B /* kernels_optimized_debug */; };
-		5C176BBF2CD5568E0015AE3B /* kernels_portable in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BBE2CD5568E0015AE3B /* kernels_portable */; };
-		5C176BC12CD5568E0015AE3B /* kernels_portable_debug in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BC02CD5568E0015AE3B /* kernels_portable_debug */; };
-		5C176BC32CD5568E0015AE3B /* kernels_quantized in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BC22CD5568E0015AE3B /* kernels_quantized */; };
-		5C176BC52CD5568E0015AE3B /* kernels_quantized_debug in Frameworks */ = {isa = PBXBuildFile; productRef = 5C176BC42CD5568E0015AE3B /* kernels_quantized_debug */; };
-		5C5E31DD2CA48AB900A0784C /* LocalInferenceImpl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C5E31D92CA48A5800A0784C /* LocalInferenceImpl.framework */; };
-		5C5E31DE2CA48AB900A0784C /* LocalInferenceImpl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C5E31D92CA48A5800A0784C /* LocalInferenceImpl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5C9590A42CD545F20092F7F0 /* tokenizer.model in Resources */ = {isa = PBXBuildFile; fileRef = 5C9590A22CD545F20092F7F0 /* tokenizer.model */; };
-		5C9590A62CD546230092F7F0 /* llama3_2_spinquant_oct23.pte in Resources */ = {isa = PBXBuildFile; fileRef = 5C9590A52CD546230092F7F0 /* llama3_2_spinquant_oct23.pte */; };
-		5C9644B22CCAC34500B80462 /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5C9644B12CCAC34500B80462 /* LlamaStackClient */; };
 		5C9644D32CCAC6A100B80462 /* LLaMARunner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */; };
 		5C9644D42CCAC6DE00B80462 /* LLaMARunner.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5CADC7012CA45670007662D2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5CADC6F72CA45670007662D2 /* Preview Assets.xcassets */; };
@@ -38,12 +19,15 @@
 		5CADC7082CA45670007662D2 /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CADC6FF2CA45670007662D2 /* MessageView.swift */; };
 		5CADC71C2CA4741B007662D2 /* LocalInferenceImpl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */; };
 		5CADC71D2CA4741B007662D2 /* LocalInferenceImpl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		BA95DFE12D7F42AE00203D37 /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = BA95DFE02D7F42AE00203D37 /* LlamaStackClient */; };
+		BAAE33D82D7B720600540213 /* llama3_2_spinquant_oct23.pte in Resources */ = {isa = PBXBuildFile; fileRef = BAAE33D62D7B720600540213 /* llama3_2_spinquant_oct23.pte */; };
+		BAAE33D92D7B720600540213 /* tokenizer.model in Resources */ = {isa = PBXBuildFile; fileRef = BAAE33D72D7B720600540213 /* tokenizer.model */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		5C5E31D82CA48A5800A0784C /* PBXContainerItemProxy */ = {
+		BA2687EB2D7A7A5F00F7058A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 5C5E31D32CA48A5800A0784C /* LocalInferenceImpl.xcodeproj */;
+			containerPortal = BA2687E42D7A7A5E00F7058A /* LocalInferenceImpl.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 5CCBC6082CA1F04A00E958D0;
 			remoteInfo = LocalInferenceImpl;
@@ -58,7 +42,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				5C9644D42CCAC6DE00B80462 /* LLaMARunner.framework in Embed Frameworks */,
-				5C5E31DE2CA48AB900A0784C /* LocalInferenceImpl.framework in Embed Frameworks */,
 				5CADC71D2CA4741B007662D2 /* LocalInferenceImpl.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -67,9 +50,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		5C5E31D32CA48A5800A0784C /* LocalInferenceImpl.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LocalInferenceImpl.xcodeproj; path = "iOSCalendarAssistantWithLocalInf/llama-stack/llama_stack/providers/impls/ios/inference/LocalInferenceImpl.xcodeproj"; sourceTree = "<group>"; };
-		5C9590A22CD545F20092F7F0 /* tokenizer.model */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = tokenizer.model; path = ../../../tokenizer.model; sourceTree = "<group>"; };
-		5C9590A52CD546230092F7F0 /* llama3_2_spinquant_oct23.pte */ = {isa = PBXFileReference; lastKnownFileType = file; path = llama3_2_spinquant_oct23.pte; sourceTree = "<group>"; };
 		5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LLaMARunner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CADB0012CA1345100942A87 /* iOSCalendarAssistantWithLocalInf.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSCalendarAssistantWithLocalInf.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CADC6F72CA45670007662D2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -81,6 +61,9 @@
 		5CADC6FE2CA45670007662D2 /* MessageListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageListView.swift; sourceTree = "<group>"; };
 		5CADC6FF2CA45670007662D2 /* MessageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageView.swift; sourceTree = "<group>"; };
 		5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LocalInferenceImpl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		BA2687E42D7A7A5E00F7058A /* LocalInferenceImpl.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LocalInferenceImpl.xcodeproj; path = "/Users/cmodi/Documents/ai/llamastack/clean/llama-stack-client-swift/local_inference/LocalInferenceImpl.xcodeproj"; sourceTree = "<absolute>"; };
+		BAAE33D62D7B720600540213 /* llama3_2_spinquant_oct23.pte */ = {isa = PBXFileReference; lastKnownFileType = file; name = llama3_2_spinquant_oct23.pte; path = /Users/cmodi/Documents/ai/clean/executorch/3b_spinquant/llama3_2_spinquant_oct23.pte; sourceTree = "<absolute>"; };
+		BAAE33D72D7B720600540213 /* tokenizer.model */ = {isa = PBXFileReference; lastKnownFileType = text; name = tokenizer.model; path = /Users/cmodi/Documents/ai/clean/executorch/3b_spinquant/tokenizer.model; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,46 +72,23 @@
 			buildActionMask = 2147483647;
 			files = (
 				5C9644D32CCAC6A100B80462 /* LLaMARunner.framework in Frameworks */,
-				5C176BBB2CD5568E0015AE3B /* kernels_optimized in Frameworks */,
-				5C9644B22CCAC34500B80462 /* LlamaStackClient in Frameworks */,
-				5C176BC52CD5568E0015AE3B /* kernels_quantized_debug in Frameworks */,
-				5C5E31DD2CA48AB900A0784C /* LocalInferenceImpl.framework in Frameworks */,
-				5C176BAD2CD556880015AE3B /* backend_coreml_debug in Frameworks */,
-				5C176BB92CD5568E0015AE3B /* kernels_custom_debug in Frameworks */,
+				BA95DFE12D7F42AE00203D37 /* LlamaStackClient in Frameworks */,
 				5CADC71C2CA4741B007662D2 /* LocalInferenceImpl.framework in Frameworks */,
-				5C176BB52CD556880015AE3B /* backend_xnnpack_debug in Frameworks */,
-				5C176BC12CD5568E0015AE3B /* kernels_portable_debug in Frameworks */,
-				5C176BB72CD5568E0015AE3B /* kernels_custom in Frameworks */,
-				5C176BBF2CD5568E0015AE3B /* kernels_portable in Frameworks */,
-				5C176BB32CD556880015AE3B /* backend_xnnpack in Frameworks */,
-				5C176BC32CD5568E0015AE3B /* kernels_quantized in Frameworks */,
-				5C176BAF2CD556880015AE3B /* backend_mps in Frameworks */,
-				5C176BBD2CD5568E0015AE3B /* kernels_optimized_debug in Frameworks */,
-				5C176BB12CD556880015AE3B /* backend_mps_debug in Frameworks */,
-				5C176BAB2CD556880015AE3B /* backend_coreml in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		5C5E31D42CA48A5800A0784C /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				5C5E31D92CA48A5800A0784C /* LocalInferenceImpl.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		5CADAFF82CA1345100942A87 = {
 			isa = PBXGroup;
 			children = (
-				5C9590A22CD545F20092F7F0 /* tokenizer.model */,
-				5C9590A52CD546230092F7F0 /* llama3_2_spinquant_oct23.pte */,
-				5C5E31D32CA48A5800A0784C /* LocalInferenceImpl.xcodeproj */,
 				5CADC7002CA45670007662D2 /* iOSCalendarAssistantWithLocalInf */,
 				5CADB0022CA1345100942A87 /* Products */,
 				5CADC7142CA467C4007662D2 /* Frameworks */,
+				BA2687E42D7A7A5E00F7058A /* LocalInferenceImpl.xcodeproj */,
+				BAAE33D62D7B720600540213 /* llama3_2_spinquant_oct23.pte */,
+				BAAE33D72D7B720600540213 /* tokenizer.model */,
 			);
 			sourceTree = "<group>";
 		};
@@ -172,6 +132,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		BA2687E82D7A7A5E00F7058A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				BA2687EC2D7A7A5F00F7058A /* LocalInferenceImpl.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -190,21 +158,7 @@
 			);
 			name = iOSCalendarAssistantWithLocalInf;
 			packageProductDependencies = (
-				5C9644B12CCAC34500B80462 /* LlamaStackClient */,
-				5C176BAA2CD556880015AE3B /* backend_coreml */,
-				5C176BAC2CD556880015AE3B /* backend_coreml_debug */,
-				5C176BAE2CD556880015AE3B /* backend_mps */,
-				5C176BB02CD556880015AE3B /* backend_mps_debug */,
-				5C176BB22CD556880015AE3B /* backend_xnnpack */,
-				5C176BB42CD556880015AE3B /* backend_xnnpack_debug */,
-				5C176BB62CD5568E0015AE3B /* kernels_custom */,
-				5C176BB82CD5568E0015AE3B /* kernels_custom_debug */,
-				5C176BBA2CD5568E0015AE3B /* kernels_optimized */,
-				5C176BBC2CD5568E0015AE3B /* kernels_optimized_debug */,
-				5C176BBE2CD5568E0015AE3B /* kernels_portable */,
-				5C176BC02CD5568E0015AE3B /* kernels_portable_debug */,
-				5C176BC22CD5568E0015AE3B /* kernels_quantized */,
-				5C176BC42CD5568E0015AE3B /* kernels_quantized_debug */,
+				BA95DFE02D7F42AE00203D37 /* LlamaStackClient */,
 			);
 			productName = StackSummary;
 			productReference = 5CADB0012CA1345100942A87 /* iOSCalendarAssistantWithLocalInf.app */;
@@ -235,15 +189,14 @@
 			);
 			mainGroup = 5CADAFF82CA1345100942A87;
 			packageReferences = (
-				5C5E31DA2CA48A8E00A0784C /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */,
-				5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */,
+				BA95DFDF2D7F42AE00203D37 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */,
 			);
 			productRefGroup = 5CADB0022CA1345100942A87 /* Products */;
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 5C5E31D42CA48A5800A0784C /* Products */;
-					ProjectRef = 5C5E31D32CA48A5800A0784C /* LocalInferenceImpl.xcodeproj */;
+					ProductGroup = BA2687E82D7A7A5E00F7058A /* Products */;
+					ProjectRef = BA2687E42D7A7A5E00F7058A /* LocalInferenceImpl.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -254,11 +207,11 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		5C5E31D92CA48A5800A0784C /* LocalInferenceImpl.framework */ = {
+		BA2687EC2D7A7A5F00F7058A /* LocalInferenceImpl.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = LocalInferenceImpl.framework;
-			remoteRef = 5C5E31D82CA48A5800A0784C /* PBXContainerItemProxy */;
+			remoteRef = BA2687EB2D7A7A5F00F7058A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -269,8 +222,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				5CADC7022CA45670007662D2 /* Assets.xcassets in Resources */,
-				5C9590A42CD545F20092F7F0 /* tokenizer.model in Resources */,
-				5C9590A62CD546230092F7F0 /* llama3_2_spinquant_oct23.pte in Resources */,
+				BAAE33D82D7B720600540213 /* llama3_2_spinquant_oct23.pte in Resources */,
+				BAAE33D92D7B720600540213 /* tokenizer.model in Resources */,
 				5CADC7012CA45670007662D2 /* Preview Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -433,35 +386,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "";
-				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_optimized-ios-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_custom-ios-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_quantized-ios-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_xnnpack-ios-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_coreml-ios-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_mps-ios-release.a",
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_optimized-simulator-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_custom-simulator-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_quantized-simulator-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_xnnpack-simulator-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_coreml-simulator-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_mps-simulator-release.a",
-				);
+				OTHER_LDFLAGS = "-lstdc++";
 				PRODUCT_BUNDLE_IDENTIFIER = meta.StackSummary;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -490,35 +415,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				OTHER_LDFLAGS = "";
-				"OTHER_LDFLAGS[sdk=iphoneos*]" = (
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_optimized-ios-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_custom-ios-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_quantized-ios-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_xnnpack-ios-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_coreml-ios-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_mps-ios-release.a",
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_optimized-simulator-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_custom-simulator-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libkernels_quantized-simulator-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_xnnpack-simulator-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_coreml-simulator-release.a",
-					"-force_load",
-					"$(BUILT_PRODUCTS_DIR)/libbackend_mps-simulator-release.a",
-				);
+				OTHER_LDFLAGS = "-lstdc++";
 				PRODUCT_BUNDLE_IDENTIFIER = meta.StackSummary;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -551,98 +448,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		5C5E31DA2CA48A8E00A0784C /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */ = {
+		BA95DFDF2D7F42AE00203D37 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/meta-llama/llama-stack-client-swift";
 			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
-		5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pytorch/executorch/";
-			requirement = {
-				branch = latest;
+				branch = "et-v0.5.0-update";
 				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		5C176BAA2CD556880015AE3B /* backend_coreml */ = {
+		BA95DFE02D7F42AE00203D37 /* LlamaStackClient */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = backend_coreml;
-		};
-		5C176BAC2CD556880015AE3B /* backend_coreml_debug */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = backend_coreml_debug;
-		};
-		5C176BAE2CD556880015AE3B /* backend_mps */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = backend_mps;
-		};
-		5C176BB02CD556880015AE3B /* backend_mps_debug */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = backend_mps_debug;
-		};
-		5C176BB22CD556880015AE3B /* backend_xnnpack */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = backend_xnnpack;
-		};
-		5C176BB42CD556880015AE3B /* backend_xnnpack_debug */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = backend_xnnpack_debug;
-		};
-		5C176BB62CD5568E0015AE3B /* kernels_custom */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = kernels_custom;
-		};
-		5C176BB82CD5568E0015AE3B /* kernels_custom_debug */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = kernels_custom_debug;
-		};
-		5C176BBA2CD5568E0015AE3B /* kernels_optimized */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = kernels_optimized;
-		};
-		5C176BBC2CD5568E0015AE3B /* kernels_optimized_debug */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = kernels_optimized_debug;
-		};
-		5C176BBE2CD5568E0015AE3B /* kernels_portable */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = kernels_portable;
-		};
-		5C176BC02CD5568E0015AE3B /* kernels_portable_debug */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = kernels_portable_debug;
-		};
-		5C176BC22CD5568E0015AE3B /* kernels_quantized */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = kernels_quantized;
-		};
-		5C176BC42CD5568E0015AE3B /* kernels_quantized_debug */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31ED2CA48FEE00A0784C /* XCRemoteSwiftPackageReference "executorch" */;
-			productName = kernels_quantized_debug;
-		};
-		5C9644B12CCAC34500B80462 /* LlamaStackClient */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31DA2CA48A8E00A0784C /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */;
+			package = BA95DFDF2D7F42AE00203D37 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */;
 			productName = LlamaStackClient;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.pbxproj
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5C9590A42CD545F20092F7F0 /* tokenizer.model in Resources */ = {isa = PBXBuildFile; fileRef = 5C9590A22CD545F20092F7F0 /* tokenizer.model */; };
+		5C9590A62CD546230092F7F0 /* llama3_2_spinquant_oct23.pte in Resources */ = {isa = PBXBuildFile; fileRef = 5C9590A52CD546230092F7F0 /* llama3_2_spinquant_oct23.pte */; };
+		5C9644B22CCAC34500B80462 /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5C9644B12CCAC34500B80462 /* LlamaStackClient */; };
 		5C9644D32CCAC6A100B80462 /* LLaMARunner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */; };
 		5C9644D42CCAC6DE00B80462 /* LLaMARunner.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5CADC7012CA45670007662D2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5CADC6F72CA45670007662D2 /* Preview Assets.xcassets */; };
@@ -19,15 +22,12 @@
 		5CADC7082CA45670007662D2 /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CADC6FF2CA45670007662D2 /* MessageView.swift */; };
 		5CADC71C2CA4741B007662D2 /* LocalInferenceImpl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */; };
 		5CADC71D2CA4741B007662D2 /* LocalInferenceImpl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BA95DFE12D7F42AE00203D37 /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = BA95DFE02D7F42AE00203D37 /* LlamaStackClient */; };
-		BAAE33D82D7B720600540213 /* llama3_2_spinquant_oct23.pte in Resources */ = {isa = PBXBuildFile; fileRef = BAAE33D62D7B720600540213 /* llama3_2_spinquant_oct23.pte */; };
-		BAAE33D92D7B720600540213 /* tokenizer.model in Resources */ = {isa = PBXBuildFile; fileRef = BAAE33D72D7B720600540213 /* tokenizer.model */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		BA2687EB2D7A7A5F00F7058A /* PBXContainerItemProxy */ = {
+		5C5E31D82CA48A5800A0784C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = BA2687E42D7A7A5E00F7058A /* LocalInferenceImpl.xcodeproj */;
+			containerPortal = 5C5E31D82CA48A5800A0784C /* LocalInferenceImpl.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 5CCBC6082CA1F04A00E958D0;
 			remoteInfo = LocalInferenceImpl;
@@ -50,6 +50,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		5C5E31D32CA48A5800A0784C /* LocalInferenceImpl.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LocalInferenceImpl.xcodeproj; path = "iOSCalendarAssistantWithLocalInf/llama-stack/llama_stack/providers/impls/ios/inference/LocalInferenceImpl.xcodeproj"; sourceTree = "<group>"; };
+		5C9590A22CD545F20092F7F0 /* tokenizer.model */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = tokenizer.model; path = ../../../tokenizer.model; sourceTree = "<group>"; };
+		5C9590A52CD546230092F7F0 /* llama3_2_spinquant_oct23.pte */ = {isa = PBXFileReference; lastKnownFileType = file; path = llama3_2_spinquant_oct23.pte; sourceTree = "<group>"; };
 		5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LLaMARunner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CADB0012CA1345100942A87 /* iOSCalendarAssistantWithLocalInf.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSCalendarAssistantWithLocalInf.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5CADC6F72CA45670007662D2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -61,9 +64,6 @@
 		5CADC6FE2CA45670007662D2 /* MessageListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageListView.swift; sourceTree = "<group>"; };
 		5CADC6FF2CA45670007662D2 /* MessageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageView.swift; sourceTree = "<group>"; };
 		5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LocalInferenceImpl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		BA2687E42D7A7A5E00F7058A /* LocalInferenceImpl.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = LocalInferenceImpl.xcodeproj; path = "/Users/cmodi/Documents/ai/llamastack/clean/llama-stack-client-swift/local_inference/LocalInferenceImpl.xcodeproj"; sourceTree = "<absolute>"; };
-		BAAE33D62D7B720600540213 /* llama3_2_spinquant_oct23.pte */ = {isa = PBXFileReference; lastKnownFileType = file; name = llama3_2_spinquant_oct23.pte; path = /Users/cmodi/Documents/ai/clean/executorch/3b_spinquant/llama3_2_spinquant_oct23.pte; sourceTree = "<absolute>"; };
-		BAAE33D72D7B720600540213 /* tokenizer.model */ = {isa = PBXFileReference; lastKnownFileType = text; name = tokenizer.model; path = /Users/cmodi/Documents/ai/clean/executorch/3b_spinquant/tokenizer.model; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,15 +80,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5C5E31D42CA48A5800A0784C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5C5E31D92CA48A5800A0784C /* LocalInferenceImpl.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		5CADAFF82CA1345100942A87 = {
 			isa = PBXGroup;
 			children = (
+				5C9590A22CD545F20092F7F0 /* tokenizer.model */,
+				5C9590A52CD546230092F7F0 /* llama3_2_spinquant_oct23.pte */,
+				5C5E31D32CA48A5800A0784C /* LocalInferenceImpl.xcodeproj */,
 				5CADC7002CA45670007662D2 /* iOSCalendarAssistantWithLocalInf */,
 				5CADB0022CA1345100942A87 /* Products */,
 				5CADC7142CA467C4007662D2 /* Frameworks */,
-				BA2687E42D7A7A5E00F7058A /* LocalInferenceImpl.xcodeproj */,
-				BAAE33D62D7B720600540213 /* llama3_2_spinquant_oct23.pte */,
-				BAAE33D72D7B720600540213 /* tokenizer.model */,
 			);
 			sourceTree = "<group>";
 		};
@@ -132,10 +140,10 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		BA2687E82D7A7A5E00F7058A /* Products */ = {
+		BAFF5EF92D80E92E00E1D87B /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				BA2687EC2D7A7A5F00F7058A /* LocalInferenceImpl.framework */,
+				BAFF5EFD2D80E92E00E1D87B /* LocalInferenceImpl.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -195,8 +203,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = BA2687E82D7A7A5E00F7058A /* Products */;
-					ProjectRef = BA2687E42D7A7A5E00F7058A /* LocalInferenceImpl.xcodeproj */;
+					ProductGroup = BAFF5EF92D80E92E00E1D87B /* Products */;
+					ProjectRef = BAFF5EF52D80E92E00E1D87B /* LocalInferenceImpl.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -207,11 +215,11 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		BA2687EC2D7A7A5F00F7058A /* LocalInferenceImpl.framework */ = {
+		BAFF5EFD2D80E92E00E1D87B /* LocalInferenceImpl.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = LocalInferenceImpl.framework;
-			remoteRef = BA2687EB2D7A7A5F00F7058A /* PBXContainerItemProxy */;
+			remoteRef = BAFF5EFC2D80E92E00E1D87B /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -222,8 +230,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				5CADC7022CA45670007662D2 /* Assets.xcassets in Resources */,
-				BAAE33D82D7B720600540213 /* llama3_2_spinquant_oct23.pte in Resources */,
-				BAAE33D92D7B720600540213 /* tokenizer.model in Resources */,
+				5C9590A42CD545F20092F7F0 /* tokenizer.model in Resources */,
+				5C9590A62CD546230092F7F0 /* llama3_2_spinquant_oct23.pte in Resources
 				5CADC7012CA45670007662D2 /* Preview Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -448,20 +456,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		BA95DFDF2D7F42AE00203D37 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */ = {
+		5C5E31DA2CA48A8E00A0784C /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/meta-llama/llama-stack-client-swift";
 			requirement = {
-				branch = "et-v0.5.0-update";
+				branch = "test-et-main";
 				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		BA95DFE02D7F42AE00203D37 /* LlamaStackClient */ = {
+		5C9644B12CCAC34500B80462 /* LlamaStackClient */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = BA95DFDF2D7F42AE00203D37 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */;
+			package = 5C5E31DA2CA48A8E00A0784C /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */;
 			productName = LlamaStackClient;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.pbxproj
+++ b/examples/ios_calendar_assistant/iOSCalendarAssistantWithLocalInf.xcodeproj/project.pbxproj
@@ -9,10 +9,8 @@
 /* Begin PBXBuildFile section */
 		5C9590A42CD545F20092F7F0 /* tokenizer.model in Resources */ = {isa = PBXBuildFile; fileRef = 5C9590A22CD545F20092F7F0 /* tokenizer.model */; };
 		5C9590A62CD546230092F7F0 /* llama3_2_spinquant_oct23.pte in Resources */ = {isa = PBXBuildFile; fileRef = 5C9590A52CD546230092F7F0 /* llama3_2_spinquant_oct23.pte */; };
-		5C9644B22CCAC34500B80462 /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = 5C9644B12CCAC34500B80462 /* LlamaStackClient */; };
 		5C9644D32CCAC6A100B80462 /* LLaMARunner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */; };
 		5C9644D42CCAC6DE00B80462 /* LLaMARunner.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5C9644D22CCAC6A100B80462 /* LLaMARunner.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5CADC7012CA45670007662D2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5CADC6F72CA45670007662D2 /* Preview Assets.xcassets */; };
 		5CADC7022CA45670007662D2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5CADC6F92CA45670007662D2 /* Assets.xcassets */; };
 		5CADC7032CA45670007662D2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CADC6FA2CA45670007662D2 /* ContentView.swift */; };
 		5CADC7042CA45670007662D2 /* EventEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CADC6FB2CA45670007662D2 /* EventEditView.swift */; };
@@ -22,17 +20,8 @@
 		5CADC7082CA45670007662D2 /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CADC6FF2CA45670007662D2 /* MessageView.swift */; };
 		5CADC71C2CA4741B007662D2 /* LocalInferenceImpl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */; };
 		5CADC71D2CA4741B007662D2 /* LocalInferenceImpl.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5CADC71B2CA4741B007662D2 /* LocalInferenceImpl.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		BA2967392D814ED4006AB504 /* LlamaStackClient in Frameworks */ = {isa = PBXBuildFile; productRef = BA2967382D814ED4006AB504 /* LlamaStackClient */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		5C5E31D82CA48A5800A0784C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 5C5E31D82CA48A5800A0784C /* LocalInferenceImpl.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 5CCBC6082CA1F04A00E958D0;
-			remoteInfo = LocalInferenceImpl;
-		};
-/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		5CADC7172CA467C4007662D2 /* Embed Frameworks */ = {
@@ -72,7 +61,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5C9644D32CCAC6A100B80462 /* LLaMARunner.framework in Frameworks */,
-				BA95DFE12D7F42AE00203D37 /* LlamaStackClient in Frameworks */,
+				BA2967392D814ED4006AB504 /* LlamaStackClient in Frameworks */,
 				5CADC71C2CA4741B007662D2 /* LocalInferenceImpl.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -80,14 +69,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		5C5E31D42CA48A5800A0784C /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				5C5E31D92CA48A5800A0784C /* LocalInferenceImpl.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		5CADAFF82CA1345100942A87 = {
 			isa = PBXGroup;
 			children = (
@@ -140,14 +121,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		BAFF5EF92D80E92E00E1D87B /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				BAFF5EFD2D80E92E00E1D87B /* LocalInferenceImpl.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -166,7 +139,7 @@
 			);
 			name = iOSCalendarAssistantWithLocalInf;
 			packageProductDependencies = (
-				BA95DFE02D7F42AE00203D37 /* LlamaStackClient */,
+				BA2967382D814ED4006AB504 /* LlamaStackClient */,
 			);
 			productName = StackSummary;
 			productReference = 5CADB0012CA1345100942A87 /* iOSCalendarAssistantWithLocalInf.app */;
@@ -197,32 +170,16 @@
 			);
 			mainGroup = 5CADAFF82CA1345100942A87;
 			packageReferences = (
-				BA95DFDF2D7F42AE00203D37 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */,
+				BA2967372D814ED4006AB504 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */,
 			);
 			productRefGroup = 5CADB0022CA1345100942A87 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = BAFF5EF92D80E92E00E1D87B /* Products */;
-					ProjectRef = BAFF5EF52D80E92E00E1D87B /* LocalInferenceImpl.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				5CADB0002CA1345100942A87 /* iOSCalendarAssistantWithLocalInf */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		BAFF5EFD2D80E92E00E1D87B /* LocalInferenceImpl.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = LocalInferenceImpl.framework;
-			remoteRef = BAFF5EFC2D80E92E00E1D87B /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		5CADAFFF2CA1345100942A87 /* Resources */ = {
@@ -231,8 +188,7 @@
 			files = (
 				5CADC7022CA45670007662D2 /* Assets.xcassets in Resources */,
 				5C9590A42CD545F20092F7F0 /* tokenizer.model in Resources */,
-				5C9590A62CD546230092F7F0 /* llama3_2_spinquant_oct23.pte in Resources
-				5CADC7012CA45670007662D2 /* Preview Assets.xcassets in Resources */,
+				5C9590A62CD546230092F7F0 /* llama3_2_spinquant_oct23.pte in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -456,20 +412,20 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		5C5E31DA2CA48A8E00A0784C /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */ = {
+		BA2967372D814ED4006AB504 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/meta-llama/llama-stack-client-swift";
 			requirement = {
-				branch = "test-et-main";
+				branch = "latest-release";
 				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		5C9644B12CCAC34500B80462 /* LlamaStackClient */ = {
+		BA2967382D814ED4006AB504 /* LlamaStackClient */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 5C5E31DA2CA48A8E00A0784C /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */;
+			package = BA2967372D814ED4006AB504 /* XCRemoteSwiftPackageReference "llama-stack-client-swift" */;
 			productName = LlamaStackClient;
 		};
 /* End XCSwiftPackageProductDependency section */


### PR DESCRIPTION
# What does this PR do?

This PR cleans-up the project dependency within the iOSCalendarAssitantWithLocalInf:
 - Add LlamaStackClient (Swift SDK) project dependency
 - Remove ExecuTorch dependency. As a result, remove the force-loading of the backends which causes re-registering issues. ExecuTorch will now be sourced from the Swift SDK only. This is be improved even further.
 - Maintain reference dummy files for tokenizer, model pte, and Swift SDK project. This can also be improved further.

Overall, this was part of the effort to be able to update the ExecuTorch module in the Swift SDK ([PR](https://github.com/meta-llama/llama-stack-client-swift/pull/27)).

## Feature/Issue validation/testing/test plan

This has been tested with the [iOSCalendarAssistantWithLocaInfr project](https://github.com/meta-llama/llama-stack-apps/tree/main/examples/ios_calendar_assistant) and Llama 3.2-3B Spinquant pte + tokenizer.model. We are able to ask "What is the capital of France" and it generates a response.
