### PR TITLE
Fix typo in generate_descriptions.py

### DIFF
--- a/examples/interior_design_assistant/generate_descriptions.py
+++ b/examples/interior_design_assistant/generate_descriptions.py
@@ -74,7 +74,7 @@ def main(host: str, port: int, image_dir: str, output_dir: str):
         with open(memory_dir / f"{p}.txt", "w") as f:
             f.write(response)
 
-        print(f"Finsihed processing {p}")
+        print(f"Finished processing {p}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix typo in `examples/interior_design_assistant/generate_descriptions.py`.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
